### PR TITLE
Throw error on nonalphanumeric namespace

### DIFF
--- a/lib/chatskills.js
+++ b/lib/chatskills.js
@@ -104,6 +104,9 @@ var ChatSkillsManager = {
 
     add: function(namespace) {
         // Add a new skill (app namespace).
+        if (/[^A-Z0-9a-z]/.test(namespace)) {
+            throw new Error('a skill name may only contain alphanumeric characters');
+        }
         this.apps[namespace] = new alexa.app(namespace);
         return this.apps[namespace];
     },

--- a/package.json
+++ b/package.json
@@ -12,9 +12,15 @@
     "url": "git://github.com/primaryobjects/chatskills.git"
   },
   "main": "./lib",
+  "scripts": {
+    "test": "node test/*.test.js"
+  },
   "dependencies": {
     "readline-sync": "*",
     "alexa-app": "*"
+  },
+  "devDependencies": {
+    "tape": "^4.6.3"
   },
   "engines": {
     "node": "*"

--- a/test/addapp.test.js
+++ b/test/addapp.test.js
@@ -1,0 +1,23 @@
+var test = require('tape');
+var chatskills = require('../lib/chatskills');
+
+test("app/skill creation with `app` succeeds", function(t) {
+  t.doesNotThrow(function() { chatskills.app('hello') }, Error);
+  t.end();
+});
+
+test("app/skill creation with `app` returns a value", function(t) {
+  var hello = chatskills.app('hello');
+  t.ok(hello);
+  t.end();
+});
+
+test("app/skill creation with `app` fails with error when namespace is non-alphanumeric", function(t) {
+  t.throws(function() { chatskills.app('hel lo') }, Error);
+  t.throws(function() { chatskills.app('hel lo') }, /skill.*characters/);
+  t.throws(function() { chatskills.app('hel_lo') }, Error);
+  t.throws(function() { chatskills.app('hel_lo') }, /skill.*characters/);
+  t.throws(function() { chatskills.app('hel-lo') }, Error);
+  t.throws(function() { chatskills.app('hel-lo') }, /skill.*characters/);
+  t.end();
+});


### PR DESCRIPTION
[Closes #2]

Here's the PR to prevent users from accidentally choosing a namespace for a skill that will cause errors later.

I have 2 separate commits. The first sets up a minimal `tape` test environment and a single unit test for the error. If you're like me, you're more comfortable squashing a bug when there's a test to demonstrate it's fixed. However, if you don't want the dev dependency on `tape`, which also pulls a number of other packages in (even though it's supposed to be the lightweight testing alternative), or you prefer a different library like `mocha` or `jasmine`, feel free to ask me to discard or change this commit.

The second commit has the actual edit to `chatskills.js`. I decided to keep it as simple as I could, so I have a RegExp test for non-alphanumerics. I did not extract the namespace part of the RegExp expression in the `session` method because I think it would be difficult to use the partial pattern both in the `add` method and the `session` method. I don't think RegExps do not compose easily. Again, if you'd prefer I try to DRY things out, let me know.